### PR TITLE
Avoid warnings, use line continuations

### DIFF
--- a/lib/log4r/formatter/formatter.rb
+++ b/lib/log4r/formatter/formatter.rb
@@ -69,8 +69,8 @@ module Log4r
 
     def format_object(obj)
       if obj.kind_of? Exception
-        return "Caught #{obj.class}: #{obj.message}\n\t" +
-               (obj.backtrace.nil? ? [] : obj.backtrace[0...@depth]).join("\n\t")
+        return "Caught #{obj.class}: #{obj.message}\n\t" \
+               "#{(obj.backtrace.nil? ? [] : obj.backtrace[0...@depth]).join("\n\t")}"
       elsif obj.kind_of? String
         return obj
       else # inspect the object

--- a/lib/log4r/outputter/outputter.rb
+++ b/lib/log4r/outputter/outputter.rb
@@ -51,8 +51,8 @@ module Log4r
       @level = levels.sort.first
       OutputterFactory.create_methods self, levels
       Logger.log_internal {
-        "Outputter '#{@name}' writes only on " +
-        levels.collect{|l| LNAMES[l]}.join(", ")
+        "Outputter '#{@name}' writes only on" \
+        " #{levels.collect{|l| LNAMES[l]}.join(", ")}"
       }
     end
 


### PR DESCRIPTION
This PR changes some logging code to use line continuation on a long string.

Here's a typical issue that this avoids:

```shell
$ rvm jruby-9.1.5.0 do ruby lib/log4r/outputter/outputter.rb
/Users/olle/.rvm/gems/jruby-9.1.5.0/gems/log4r-1.1.10/lib/log4r/outputter/outputter.rb:54: warning: `+' after local variable or literal is interpreted as binary operator
/Users/olle/.rvm/gems/jruby-9.1.5.0/gems/log4r-1.1.10/lib/log4r/outputter/outputter.rb:54: warning: even though it seems like unary operator
/Users/olle/.rvm/gems/jruby-9.1.5.0/gems/log4r-1.1.10/lib/log4r/formatter/formatter.rb:72: warning: `+' after local variable or literal is interpreted as binary operator
/Users/olle/.rvm/gems/jruby-9.1.5.0/gems/log4r-1.1.10/lib/log4r/formatter/formatter.rb:72: warning: even though it seems like unary operator
```